### PR TITLE
refactor: remove SSG exports from bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Preact Framework for Deno. Dext.ts is heavily inspired by Next.js.
 
 - Zero config
 - Pre-render pages at build time (SSG)
-- Tiny (example is only 6.2KB of JS)
+- Tiny (example is only 5.9KB of JS)
 - Client hydration
 - Built-in routing
 - Zero config TypeScript support

--- a/cli.ts
+++ b/cli.ts
@@ -80,6 +80,7 @@ async function build(_options: unknown, root?: string) {
     JSON.stringify(pages.pages.map((page) => ({
       name: page.name,
       route: page.route,
+      hasGetStaticPaths: page.hasGetStaticPaths,
     }))),
   );
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -134,9 +134,11 @@ export async function bundle(
     ) as OutputChunk[];
 
     for (const out of chunks) {
-      const page = pages.pages.find((p) => p.path === out.facadeModuleId!);
       const filename = `/${out.fileName}`;
-      if (page) {
+      if (out.facadeModuleId && out.facadeModuleId.startsWith("dext-page://")) {
+        const page = pages.pages.find((p) =>
+          p.path === out.facadeModuleId!.substring("dext-page://".length)
+        )!;
         const imports = [
           flattenImports(chunks, out.fileName),
           ...out.implicitlyLoadedBefore,

--- a/src/plugins/dext.ts
+++ b/src/plugins/dext.ts
@@ -85,7 +85,9 @@ hydrate(<Dext />, document.getElementById("__dext")!);`;
       for (const name in bundle) {
         const file = bundle[name];
         if (file.type === "chunk" && file.isEntry) {
-          const component = file.facadeModuleId!.substring("dext-page://".length);
+          const component = file.facadeModuleId!.substring(
+            "dext-page://".length,
+          );
           const page = pageMap[component];
 
           const imports = [

--- a/src/plugins/dext.ts
+++ b/src/plugins/dext.ts
@@ -28,8 +28,8 @@ export function dextPlugin(
       for (const component in pageMap) {
         implicitlyLoadedAfterOneOf.push(component);
         this.emitFile({
-          id: component,
           name: pageMap[component].name.replace("/", "-"),
+          id: "dext-page://" + component,
           type: "chunk",
         });
       }
@@ -41,9 +41,17 @@ export function dextPlugin(
     },
     resolveId(source, referrer) {
       if (referrer === "dext:///main.js") return source;
+      if (referrer?.startsWith("dext-page://")) {
+        return this.resolve(source, referrer.substring("dext-page://".length));
+      }
       return null;
     },
     load(id) {
+      if (id.startsWith("dext-page://")) {
+        return `export { default } from "${
+          id.substring("dext-page://".length)
+        }";`;
+      }
       if (id == "dext:///main.js") {
         const bundle =
           `import { h, hydrate, Router, Route, AsyncRoute, Error404, loadComponent } from "${runtimeURL}";
@@ -57,7 +65,7 @@ function Dext() {
         <Router>
           ${
             Object.entries(pageMap).map(([id, page]) => {
-              return `<AsyncRoute path="${page.route}" getComponent={(path) => loadComponent(import("${id}"), ${
+              return `<AsyncRoute path="${page.route}" getComponent={(path) => loadComponent(import("dext-page://${id}"), ${
                 page.hasGetStaticData ? "true" : "false"
               }, path)} />`;
             }).join("\n        ")
@@ -77,7 +85,7 @@ hydrate(<Dext />, document.getElementById("__dext")!);`;
       for (const name in bundle) {
         const file = bundle[name];
         if (file.type === "chunk" && file.isEntry) {
-          const component = file.facadeModuleId!;
+          const component = file.facadeModuleId!.substring("dext-page://".length);
           const page = pageMap[component];
 
           const imports = [

--- a/tests/integration_test.ts
+++ b/tests/integration_test.ts
@@ -18,7 +18,7 @@ integrationTest({
       JSON.parse(
         await Deno.readTextFile(join(ctx.dir, ".dext", "pagemap.json")),
       ),
-      [{ name: "index", route: "/" }],
+      [{ name: "index", route: "/", hasGetStaticPaths: false }],
     );
 
     const staticdir = join(ctx.dir, ".dext", "static");
@@ -46,8 +46,8 @@ integrationTest({
         await Deno.readTextFile(join(ctx.dir, ".dext", "pagemap.json")),
       ),
       [
-        { name: "index", route: "/" },
-        { name: "uppercase/[str]", route: "/uppercase/:str" },
+        { name: "index", route: "/", hasGetStaticPaths: false },
+        { name: "uppercase/[str]", route: "/uppercase/:str", hasGetStaticPaths: true },
       ],
     );
 

--- a/tests/integration_test.ts
+++ b/tests/integration_test.ts
@@ -47,7 +47,11 @@ integrationTest({
       ),
       [
         { name: "index", route: "/", hasGetStaticPaths: false },
-        { name: "uppercase/[str]", route: "/uppercase/:str", hasGetStaticPaths: true },
+        {
+          name: "uppercase/[str]",
+          route: "/uppercase/:str",
+          hasGetStaticPaths: true,
+        },
       ],
     );
 


### PR DESCRIPTION
`getStaticData` and `getStaticPaths` are now not included in the client bundles anymore.

main:
```
Page                           Size     First Load JS
┌ ● /                          232 B    5.95 kB      
├ ○ /dynamic/:name             175 B    5.89 kB      
└ ● /user/:name                286 B    6 kB         
                                                     
+ First Load JS shared by all  5.72 kB               
  ├ /main-e304fa6e.js          2.22 kB               
  └ /preact-5e05c32a.js        3.5 kB                

○  (Static)  automatically rendered as static HTML
●  (SSG)     automatically generated as static HTML + JSON (uses getStaticData)
```

this PR:
```
Page                           Size     First Load JS
┌ ● /                          189 B    5.9 kB       
├ ○ /dynamic/:name             175 B    5.89 kB      
└ ● /user/:name                189 B    5.9 kB       
                                                     
+ First Load JS shared by all  5.71 kB               
  ├ /main-3437414c.js          2.22 kB               
  └ /preact-5e05c32a.js        3.5 kB                

○  (Static)  automatically rendered as static HTML
●  (SSG)     automatically generated as static HTML + JSON (uses getStaticData)

File sizes are measured after brotli compression.
```