### PR TITLE
chore: update dependencies for Deno 1.7.1

### DIFF
--- a/deps/mod.ts
+++ b/deps/mod.ts
@@ -1,4 +1,4 @@
-export { rollup } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/deps.ts";
+export { rollup } from "https://raw.githubusercontent.com/kt3k/denopack/7ee6ad76c240696b8567a9b16491a5ec14eac78f/deps.ts";
 export type {
   ModuleFormat,
   OutputAsset,
@@ -11,13 +11,13 @@ export type {
   RollupCache,
   RollupOptions,
   RollupOutput,
-} from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/deps.ts";
+} from "https://raw.githubusercontent.com/kt3k/denopack/7ee6ad76c240696b8567a9b16491a5ec14eac78f/deps.ts";
 
-export { useCache } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/plugin/mod.ts";
-export { pluginTerserTransform } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/plugin/terserTransform/mod.ts";
+export { useCache } from "https://raw.githubusercontent.com/kt3k/denopack/7ee6ad76c240696b8567a9b16491a5ec14eac78f/plugin/mod.ts";
+export { pluginTerserTransform } from "https://raw.githubusercontent.com/kt3k/denopack/7ee6ad76c240696b8567a9b16491a5ec14eac78f/plugin/terserTransform/mod.ts";
 
-export { persistSourceMaps } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/cli/persistSourceMaps.ts";
-export { emitFiles } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/cli/emitFiles.ts";
+export { persistSourceMaps } from "https://raw.githubusercontent.com/kt3k/denopack/7ee6ad76c240696b8567a9b16491a5ec14eac78f/cli/persistSourceMaps.ts";
+export { emitFiles } from "https://raw.githubusercontent.com/kt3k/denopack/7ee6ad76c240696b8567a9b16491a5ec14eac78f/cli/emitFiles.ts";
 
 // std
 export * as colors from "https://deno.land/std@0.84.0/fmt/colors.ts";

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:1.7.0 as builder
+FROM hayd/alpine-deno:1.7.1 as builder
 WORKDIR /app
 RUN deno cache --unstable https://deno.land/x/dext@0.10.3/cli.ts
 COPY deps.ts deps.ts
@@ -7,7 +7,7 @@ RUN deno cache -c tsconfig.json deps.ts
 COPY . .
 RUN deno run --allow-read --allow-write --allow-env --allow-net --allow-run --unstable https://deno.land/x/dext@0.10.3/cli.ts build
 
-FROM hayd/alpine-deno:1.7.0
+FROM hayd/alpine-deno:1.7.1
 WORKDIR /app
 RUN deno cache --unstable https://deno.land/x/dext@0.10.3/cli.ts
 COPY --from=builder /app/.dext /app/.dext


### PR DESCRIPTION
This PR updates the dependencies for Deno 1.7.1.

Deno 1.7.1 doesn't work well with the latest denopack because the dependency to https://deno.land/std@0.66.0/node/process.ts causes the type error while type checking.

I removed that dependency (`std@0.66.0/node`) by switching the dependency of `@rollup/pluginutils` from "https://cdn.dreg.dev/package/@rollup/pluginutils@4.0.0" to "https://esm.sh/@rollup/pluginutils@4.0.0" in https://github.com/kt3k/denopack/commit/7ee6ad76c240696b8567a9b16491a5ec14eac78f

While this just works depending on my fork, I'm going to update this PR when https://github.com/denofn/denopack/pull/48 and the above commit are merged in denopack.