### PR TITLE
Use Deno.execPath() for deno command

### DIFF
--- a/src/dependency_graph.ts
+++ b/src/dependency_graph.ts
@@ -11,7 +11,14 @@ export interface Dep {
 
 async function runDenoInfo(entrypoint: string): Promise<DepGraph> {
   const p = Deno.run({
-    cmd: ["deno", "info", "--json", "--unstable", "--no-check", entrypoint],
+    cmd: [
+      Deno.execPath(),
+      "info",
+      "--json",
+      "--unstable",
+      "--no-check",
+      entrypoint,
+    ],
     stdout: "piped",
     stderr: "inherit",
   });

--- a/src/plugins/dext.ts
+++ b/src/plugins/dext.ts
@@ -189,7 +189,7 @@ async function getStaticPaths(
   );
   const proc = Deno.run({
     cmd: [
-      "deno",
+      Deno.execPath(),
       "run",
       "-A",
       "-q",
@@ -225,7 +225,7 @@ async function getStaticData(
   );
   const proc = Deno.run({
     cmd: [
-      "deno",
+      Deno.execPath(),
       "run",
       "-A",
       "-q",
@@ -264,7 +264,7 @@ async function prerenderDocument(
   );
   const proc = Deno.run({
     cmd: [
-      "deno",
+      Deno.execPath(),
       "run",
       "-A",
       "-q",
@@ -310,7 +310,7 @@ async function prerenderPage(
   );
   const proc = Deno.run({
     cmd: [
-      "deno",
+      Deno.execPath(),
       "run",
       "-A",
       "-q",

--- a/src/util.ts
+++ b/src/util.ts
@@ -119,7 +119,7 @@ export async function checkHasDataHooks(
   hasGetStaticData: boolean;
 }> {
   const proc = Deno.run({
-    cmd: ["deno", "doc", "--json", path],
+    cmd: [Deno.execPath(), "doc", "--json", path],
     stdout: "piped",
     stderr: "inherit",
   });

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -27,7 +27,7 @@ export function integrationTest(options: {
       const cli = new URL("../cli.ts", import.meta.url).toString();
 
       const proc = Deno.run({
-        cmd: ["deno", "run", "-A", "--unstable", cli, ...options.cmd],
+        cmd: [Deno.execPath(), "run", "-A", "--unstable", cli, ...options.cmd],
         cwd: dir,
         stdout: "piped",
         stderr: "piped",


### PR DESCRIPTION
This make it possible to run `dext dev` and `dext build` even when `deno` command is not available in $PATH.

In some CI environment, deno is not available and we need to run it like `/abs-path/to/deno run ...`. In that case, the current implementation is a little inconvenient.