### PR TITLE
fix: ignore query string in href or navigate

### DIFF
--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -6,7 +6,7 @@ interface Data {
 }
 
 function IndexPage(props: PageProps<Data>) {
-  const [path] = useLocation();
+  const [path, navigate] = useLocation();
 
   return (
     <>
@@ -15,6 +15,20 @@ function IndexPage(props: PageProps<Data>) {
       <p>The random is {props.data.random}.</p>
       <p>
         <a href="/user/luca">Go to @luca</a>
+      </p>
+      <p>
+        <a href="/user/luca?foo=1&bar=2">Go to @luca with query params</a>
+      </p>
+      <p>
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate("/user/luca?baz=3");
+          }}
+        >
+          Go to @luca with query params with navigate
+        </a>
       </p>
     </>
   );

--- a/example/pages/user/[name].tsx
+++ b/example/pages/user/[name].tsx
@@ -18,6 +18,7 @@ function UserPage(props: PageProps<Props>) {
       <h1>
         This is the page for {name} - {props.data.capitalizedName}
       </h1>
+      {location.search && <p>query string is "{location.search}"</p>}
       <p>
         <a href="/">Go home</a>
       </p>

--- a/src/runtime/mod.tsx
+++ b/src/runtime/mod.tsx
@@ -50,7 +50,7 @@ function Dext(props: {
   const navigate = useCallback(
     (to: string) => {
       window.history.pushState(null, "", to);
-      setDesiredPath(to);
+      setDesiredPath(new URL(to, location.href).pathname);
     },
     [setDesiredPath],
   );

--- a/src/runtime/router/interceptor.ts
+++ b/src/runtime/router/interceptor.ts
@@ -20,7 +20,8 @@ export function initRouter(
       return;
     }
 
-    const [route] = router.getRoute(href);
+    const { pathname } = new URL(href, location.href);
+    const [route] = router.getRoute(pathname);
     if (route) {
       navigate(href);
       return true;


### PR DESCRIPTION
This PR enables to use query strings when navigating in a dext-built site. You can check the behavior in `example` site.

With this change, `<a href="/some/page?some=param">...</a>` and `navigate("/some/page?some=param")` work.