### PR TITLE
feat: add sourcemap and minify options

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -43,6 +43,16 @@ try {
       "If preact/debug should be included in the bundle.",
       { default: false },
     )
+    .option(
+      "--sourcemap [enabled:boolean]",
+      "If sourcemap should be generated",
+      { default: true },
+    )
+    .option(
+      "--minify [enabled:boolean]",
+      "If the source should be minified",
+      { default: true },
+    )
     .description("Build your application.")
     .action(build)
     .command("start [root]")
@@ -96,7 +106,13 @@ try {
 }
 
 async function build(
-  options: { typecheck: boolean; prerender: boolean; debug: boolean },
+  options: {
+    typecheck: boolean;
+    prerender: boolean;
+    debug: boolean;
+    sourcemap: boolean;
+    minify: boolean;
+  },
   root?: string,
 ) {
   root = path.resolve(Deno.cwd(), root ?? "");
@@ -134,7 +150,8 @@ async function build(
     rootDir: root,
     outDir,
     tsconfigPath,
-    minify: true,
+    minify: options.minify,
+    sourcemap: options.sourcemap,
     hotRefresh: false,
     typecheck: options.typecheck,
     prerender: options.prerender,
@@ -276,6 +293,7 @@ async function dev(
         tsconfigPath,
         cache,
         minify: false,
+        sourcemap: true,
         hotRefresh: options.hotRefresh,
         hotRefreshHost: options.hotRefreshHost,
         typecheck: options.typecheck,

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -46,6 +46,7 @@ export async function bundle(
     cache?: RollupCache;
     typecheck: boolean;
     minify: boolean;
+    sourcemap: boolean;
     prerender: boolean;
     hotRefresh: boolean;
     hotRefreshHost?: string;
@@ -55,8 +56,8 @@ export async function bundle(
   const outputOptions: OutputOptions = {
     dir: options.outDir,
     format: "es",
-    sourcemap: true,
-    compact: true,
+    sourcemap: options.sourcemap,
+    compact: options.minify,
     chunkFileNames: "static/[name]-[hash].js",
     assetFileNames: "assets/[name]-[hash][extname]",
   };


### PR DESCRIPTION
This PR adds `sourcemap` and `minify` option for `build` command. This reduces the build time of `dext build` when these are disabled.

When I measured the effect of these options with example directory, it reduced 23% build time on my machine ( 7.400s -> 5.680s ) (measured with `build --typecheck=false`.)