### PR TITLE
chore: update for deno v1.9.1

### DIFF
--- a/deps/mod.ts
+++ b/deps/mod.ts
@@ -20,11 +20,16 @@ export { persistSourceMaps } from "https://raw.githubusercontent.com/denofn/deno
 export { emitFiles } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/cli/emitFiles.ts";
 
 // std
-export * as colors from "https://deno.land/std@0.88.0/fmt/colors.ts";
-export * as path from "https://deno.land/std@0.88.0/path/mod.ts";
-export * as fs from "https://deno.land/std@0.88.0/fs/mod.ts";
-export { deferred, pooledMap } from "https://deno.land/std@0.88.0/async/mod.ts";
-export { format as dateFormat } from "https://deno.land/std@0.88.0/datetime/mod.ts";
+export * as colors from "https://deno.land/std@0.93.0/fmt/colors.ts";
+export * as path from "https://deno.land/std@0.93.0/path/mod.ts";
+export * as fs from "https://deno.land/std@0.93.0/fs/mod.ts";
+export { deferred, pooledMap } from "https://deno.land/std@0.93.0/async/mod.ts";
+export { format as dateFormat } from "https://deno.land/std@0.93.0/datetime/mod.ts";
+export {
+  readAll,
+  writeAll,
+  writeAllSync,
+} from "https://deno.land/std@0.93.0/io/util.ts";
 
 export {
   Command,

--- a/src/plugins/dext.ts
+++ b/src/plugins/dext.ts
@@ -1,4 +1,4 @@
-import { compile, path, Plugin, pooledMap } from "../../deps/mod.ts";
+import { compile, path, Plugin, pooledMap, writeAll } from "../../deps/mod.ts";
 import type { GetStaticDataContext, GetStaticPaths } from "../type.ts";
 import type { Page, Pages } from "../util.ts";
 
@@ -174,7 +174,7 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 async function noNewlineLog(str: string) {
-  await Deno.writeAll(Deno.stdout, encoder.encode(str));
+  await writeAll(Deno.stdout, encoder.encode(str));
 }
 
 async function getStaticPaths(
@@ -239,7 +239,7 @@ async function getStaticData(
     stdout: "piped",
     stderr: "inherit",
   });
-  await Deno.writeAll(
+  await writeAll(
     proc.stdin,
     new TextEncoder().encode(JSON.stringify(context)),
   );
@@ -327,7 +327,7 @@ async function prerenderPage(
     stdout: "piped",
     stderr: "inherit",
   });
-  await Deno.writeAll(
+  await writeAll(
     proc.stdin,
     new TextEncoder().encode(JSON.stringify(context)),
   );

--- a/src/runtime/prerender_document_host.tsx
+++ b/src/runtime/prerender_document_host.tsx
@@ -1,9 +1,10 @@
 import { h } from "../../deps/preact/mod.ts";
 import { render } from "../../deps/preact/ssr.ts";
+import { writeAllSync } from "../../deps/mod.ts";
 
 const Document = await import(Deno.args[0]).then((m) => m.default);
 const body = render(<Document />);
-Deno.writeAllSync(
+writeAllSync(
   Deno.stdout,
   new TextEncoder().encode(`<!--dextstart-->${body}<!--dextend-->`),
 );

--- a/src/runtime/prerender_page_host.tsx
+++ b/src/runtime/prerender_page_host.tsx
@@ -1,5 +1,6 @@
 import { h } from "../../deps/preact/mod.ts";
 import type { ComponentType } from "../../deps/preact/mod.ts";
+import { readAll, writeAllSync } from "../../deps/mod.ts";
 import { render } from "../../deps/preact/ssr.ts";
 import type { AppProps, PageProps } from "./type.ts";
 
@@ -9,7 +10,7 @@ const Component: ComponentType<PageProps> = await import(Deno.args[0]).then(
 const App: ComponentType<AppProps> = await import(Deno.args[1]).then(
   (m) => m.default,
 );
-const rawData: Uint8Array = await Deno.readAll(Deno.stdin);
+const rawData: Uint8Array = await readAll(Deno.stdin);
 const { data, route } = rawData.length == 0
   ? undefined
   : JSON.parse(new TextDecoder().decode(rawData));
@@ -22,7 +23,7 @@ const body = render(
     </App>
   </div>,
 );
-Deno.writeAllSync(
+writeAllSync(
   Deno.stdout,
   new TextEncoder().encode(`<!--dextstart-->${body}<!--dextend-->`),
 );

--- a/src/runtime/static_data_host.ts
+++ b/src/runtime/static_data_host.ts
@@ -1,8 +1,10 @@
+import { readAll } from "../../deps/mod.ts";
+
 const [{ getStaticData }, rawData]: [
   // deno-lint-ignore ban-types
   { getStaticData: Function },
   Uint8Array,
-] = await Promise.all([import(Deno.args[0]), Deno.readAll(Deno.stdin)]);
+] = await Promise.all([import(Deno.args[0]), readAll(Deno.stdin)]);
 const data = rawData.length == 0
   ? undefined
   : JSON.parse(new TextDecoder().decode(rawData));


### PR DESCRIPTION
Fixed lint errors, but test code doesn't pass type checking.

If I change the lib of tsconfig in fixtures directory to `"lib": ["esnext", "dom", "dom.iterable", "dom.asynciterable", "deno.ns", "deno.unstable"],`, the number of type errors are reduced, but it still shows `Property 'getIterator' does not exist on type 'ReadableStream<R>'` at `https://deno.land/std@0.69.0/async/pool.t`.