### PR TITLE
chore: reduce dependencies

### DIFF
--- a/deps/mod.ts
+++ b/deps/mod.ts
@@ -21,11 +21,16 @@ export { persistSourceMaps } from "https://raw.githubusercontent.com/denofn/deno
 export { emitFiles } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/cli/emitFiles.ts";
 
 // std
-export * as colors from "https://deno.land/std@0.88.0/fmt/colors.ts";
-export * as path from "https://deno.land/std@0.88.0/path/mod.ts";
-export * as fs from "https://deno.land/std@0.88.0/fs/mod.ts";
-export { deferred, pooledMap } from "https://deno.land/std@0.88.0/async/mod.ts";
-export { format as dateFormat } from "https://deno.land/std@0.88.0/datetime/mod.ts";
+export * as colors from "https://deno.land/std@0.93.0/fmt/colors.ts";
+export * as path from "https://deno.land/std@0.93.0/path/mod.ts";
+export * as fs from "https://deno.land/std@0.93.0/fs/mod.ts";
+export { deferred, pooledMap } from "https://deno.land/std@0.93.0/async/mod.ts";
+export { format as dateFormat } from "https://deno.land/std@0.93.0/datetime/mod.ts";
+export {
+  readAll,
+  writeAll,
+  writeAllSync,
+} from "https://deno.land/std@0.93.0/io/util.ts";
 
 export {
   Command,

--- a/deps/mod.ts
+++ b/deps/mod.ts
@@ -1,4 +1,5 @@
-export { rollup } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/deps.ts";
+// @deno-types="https://unpkg.com/rollup@2.26.11/dist/rollup.d.ts"
+export { rollup } from "https://unpkg.com/rollup@2.26.11/dist/es/rollup.browser.js";
 export type {
   ModuleFormat,
   OutputAsset,
@@ -11,9 +12,9 @@ export type {
   RollupCache,
   RollupOptions,
   RollupOutput,
-} from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/deps.ts";
+} from "https://unpkg.com/rollup@2.26.11/dist/rollup.d.ts";
 
-export { useCache } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/plugin/mod.ts";
+export { useCache } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/plugin/hooks.ts";
 export { pluginTerserTransform } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/plugin/terserTransform/mod.ts";
 
 export { persistSourceMaps } from "https://raw.githubusercontent.com/denofn/denopack/8bae39bef47e532a1e8d0f6700b72a2192f7bca4/cli/persistSourceMaps.ts";

--- a/src/plugins/dext.ts
+++ b/src/plugins/dext.ts
@@ -1,4 +1,4 @@
-import { compile, path, Plugin, pooledMap } from "../../deps/mod.ts";
+import { compile, path, Plugin, pooledMap, writeAll } from "../../deps/mod.ts";
 import type { GetStaticDataContext, GetStaticPaths } from "../type.ts";
 import type { Page, Pages } from "../util.ts";
 
@@ -174,7 +174,7 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 async function noNewlineLog(str: string) {
-  await Deno.writeAll(Deno.stdout, encoder.encode(str));
+  await writeAll(Deno.stdout, encoder.encode(str));
 }
 
 async function getStaticPaths(
@@ -239,7 +239,7 @@ async function getStaticData(
     stdout: "piped",
     stderr: "inherit",
   });
-  await Deno.writeAll(
+  await writeAll(
     proc.stdin,
     new TextEncoder().encode(JSON.stringify(context)),
   );
@@ -327,7 +327,7 @@ async function prerenderPage(
     stdout: "piped",
     stderr: "inherit",
   });
-  await Deno.writeAll(
+  await writeAll(
     proc.stdin,
     new TextEncoder().encode(JSON.stringify(context)),
   );

--- a/src/runtime/prerender_document_host.tsx
+++ b/src/runtime/prerender_document_host.tsx
@@ -1,9 +1,10 @@
 import { h } from "../../deps/preact/mod.ts";
 import { render } from "../../deps/preact/ssr.ts";
+import { writeAllSync } from "../../deps/mod.ts";
 
 const Document = await import(Deno.args[0]).then((m) => m.default);
 const body = render(<Document />);
-Deno.writeAllSync(
+writeAllSync(
   Deno.stdout,
   new TextEncoder().encode(`<!--dextstart-->${body}<!--dextend-->`),
 );

--- a/src/runtime/prerender_page_host.tsx
+++ b/src/runtime/prerender_page_host.tsx
@@ -1,5 +1,6 @@
 import { h } from "../../deps/preact/mod.ts";
 import type { ComponentType } from "../../deps/preact/mod.ts";
+import { readAll, writeAllSync } from "../../deps/mod.ts";
 import { render } from "../../deps/preact/ssr.ts";
 import type { AppProps, PageProps } from "./type.ts";
 
@@ -9,7 +10,7 @@ const Component: ComponentType<PageProps> = await import(Deno.args[0]).then(
 const App: ComponentType<AppProps> = await import(Deno.args[1]).then(
   (m) => m.default,
 );
-const rawData: Uint8Array = await Deno.readAll(Deno.stdin);
+const rawData: Uint8Array = await readAll(Deno.stdin);
 const { data, route } = rawData.length == 0
   ? undefined
   : JSON.parse(new TextDecoder().decode(rawData));
@@ -22,7 +23,7 @@ const body = render(
     </App>
   </div>,
 );
-Deno.writeAllSync(
+writeAllSync(
   Deno.stdout,
   new TextEncoder().encode(`<!--dextstart-->${body}<!--dextend-->`),
 );

--- a/src/runtime/static_data_host.ts
+++ b/src/runtime/static_data_host.ts
@@ -1,8 +1,10 @@
+import { readAll } from "../../deps/mod.ts";
+
 const [{ getStaticData }, rawData]: [
   // deno-lint-ignore ban-types
   { getStaticData: Function },
   Uint8Array,
-] = await Promise.all([import(Deno.args[0]), Deno.readAll(Deno.stdin)]);
+] = await Promise.all([import(Deno.args[0]), readAll(Deno.stdin)]);
 const data = rawData.length == 0
   ? undefined
   : JSON.parse(new TextDecoder().decode(rawData));

--- a/tests/fixtures/full/custom_app_and_document/tsconfig.json
+++ b/tests/fixtures/full/custom_app_and_document/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "compilerOptions": {
-    "lib": ["esnext", "dom", "dom.iterable", "dom.asynciterable", "deno.ns", "deno.unstable"],
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable",
+      "dom.asynciterable",
+      "deno.ns",
+      "deno.unstable"
+    ],
     "jsx": "react",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment"

--- a/tests/fixtures/full/custom_app_and_document/tsconfig.json
+++ b/tests/fixtures/full/custom_app_and_document/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["esnext", "dom", "deno.ns"],
+    "lib": ["esnext", "dom", "dom.iterable", "dom.asynciterable", "deno.ns", "deno.unstable"],
     "jsx": "react",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment"

--- a/tests/fixtures/full/simple/tsconfig.json
+++ b/tests/fixtures/full/simple/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "compilerOptions": {
-    "lib": ["esnext", "dom", "dom.iterable", "dom.asynciterable", "deno.ns", "deno.unstable"],
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable",
+      "dom.asynciterable",
+      "deno.ns",
+      "deno.unstable"
+    ],
     "jsx": "react",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment"

--- a/tests/fixtures/full/simple/tsconfig.json
+++ b/tests/fixtures/full/simple/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["esnext", "dom", "deno.ns"],
+    "lib": ["esnext", "dom", "dom.iterable", "dom.asynciterable", "deno.ns", "deno.unstable"],
     "jsx": "react",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment"

--- a/tests/fixtures/full/static_generation/tsconfig.json
+++ b/tests/fixtures/full/static_generation/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "compilerOptions": {
-    "lib": ["esnext", "dom", "dom.iterable", "dom.asynciterable", "deno.ns", "deno.unstable"],
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable",
+      "dom.asynciterable",
+      "deno.ns",
+      "deno.unstable"
+    ],
     "jsx": "react",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment"

--- a/tests/fixtures/full/static_generation/tsconfig.json
+++ b/tests/fixtures/full/static_generation/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["esnext", "dom", "deno.ns"],
+    "lib": ["esnext", "dom", "dom.iterable", "dom.asynciterable", "deno.ns", "deno.unstable"],
     "jsx": "react",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment"


### PR DESCRIPTION
This PR reduces the unique dependencies of `cli.ts` from 307 (4.72MB) to 250 (4.29MB), and this especially excludes the problematic module `https://cdn.dreg.dev/package/@rollup/pluginutils@4.0.0`, which prevents caching of compiled module and always invokes the type checking. ref: https://github.com/denoland/deno/issues/10279

This PR also fixes lint errors for 1.9.2, and update tsconfig for fixture projects to prevent type errors.